### PR TITLE
add: ESC key as button to return to main menu

### DIFF
--- a/src/wl_play.cpp
+++ b/src/wl_play.cpp
@@ -101,6 +101,7 @@ ControlScheme controlScheme[] =
 	{ bt_automap,			"Automap",		-1,			-1,				-1, CS_AxisDigital, 0 },
 	{ bt_showstatusbar,		"Show Status",	-1,			sc_Tab,			-1,	CS_AxisDigital, 0 },
 	{ bt_pause,				"Pause",		-1,			sc_Pause,		-1, CS_AxisDigital, 0 },
+	{ bt_esc,				"Main Menu",	-1,			-1,				-1, CS_AxisDigital, 0 },
 
 	// End of List
 	{ bt_nobutton,			NULL, -1, -1, -1, CS_AxisDigital, 0 }


### PR DESCRIPTION
ESC key can be assigned to any button now. This helps to return to main menu by a button press (for example start-button). Not all gamepads offer a dedicated home button like the XBOX controllers do.

This patch is now 7 years old and I never assigned to bitbucket ;)